### PR TITLE
Add command to modify merchant stock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -297,3 +297,4 @@ dist/
 /Merchants.sln
 /*.sln
 /TODO.txt
+C:/

--- a/Commands/MerchantCommands.cs
+++ b/Commands/MerchantCommands.cs
@@ -59,4 +59,35 @@ internal static class MerchantCommands
             ctx.Reply("Not hovering over Penumbra merchant!");
         }
     }
+
+    [Command(name: "additem", shortHand: "ai", adminOnly: true,
+             usage: ".pen ai [Merchant] [Item] [Price] [Amount]",
+             description: "Adds or updates merchant stock.")]
+    public static void AddMerchantItemCommand(ChatCommandContext ctx, int merchant,
+        int item, int price, int amount)
+    {
+        int index = merchant - 1;
+
+        if (index < 0)
+        {
+            ctx.Reply("Invalid merchant index!");
+            return;
+        }
+
+        PrefabGUID itemGuid = new(item);
+        if (!PrefabCollectionSystem._PrefabGuidToEntityMap.ContainsKey(itemGuid))
+        {
+            ctx.Reply("Invalid item prefabGuid!");
+            return;
+        }
+
+        if (price <= 0 || amount <= 0)
+        {
+            ctx.Reply("Price and amount must be positive numbers!");
+            return;
+        }
+
+        AddMerchantItem(index, itemGuid, price, amount);
+        ctx.Reply($"Updated merchant {merchant} with item {itemGuid.GetPrefabName()}.");
+    }
 }

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -310,7 +310,7 @@ internal class Plugin : BasePlugin
 
         LogInstance.LogWarning("Created default merchants!");
     }
-    void SaveMerchants()
+    internal void SaveMerchants()
     {
         var keysToRemove = Config.Keys
             .Where(k => k.Section.StartsWith("Merchant", StringComparison.Ordinal))

--- a/README.md
+++ b/README.md
@@ -44,12 +44,6 @@ Jairon O.; Odjit; Jera; Kokuren TCG and Gaming Shop; Rexxn; Eduardo G.; DirtyMik
   Pace around or stay put.
 
 ## Commands
-- `.penumbra spawnmerchant [TraderPrefab] [Wares]` 🔒
-  - Spawns merchant at mouse location with configured wares ('.pen sm 1631713257 3' will spawn a major noctem trader with the third wares as configured).
-  - Shortcut: *.pen sm [TraderPrefab] [Wares]*
-- `.penumbra removemerchant` 🔒
-  - Removes hovered merchant.
-  - Shortcut: *.pen rm*
 - `.penumbra redeemtokens`
   - Redeems tokens for configured item.
   - Shortcut: *.pen rt*
@@ -59,6 +53,15 @@ Jairon O.; Odjit; Jera; Kokuren TCG and Gaming Shop; Rexxn; Eduardo G.; DirtyMik
 - `.penumbra getdaily`
   - Check time remaining or receive daily login reward if eligible.
   - Shortcut: *.pen gd*
+- `.penumbra spawnmerchant [TraderPrefab] [Wares]` 🔒
+  - Spawns merchant at mouse location with configured wares ('.pen sm 1631713257 3' will spawn a major noctem trader with the third wares as configured).
+  - Shortcut: *.pen sm [TraderPrefab] [Wares]*
+- `.penumbra removemerchant` 🔒
+  - Removes hovered merchant.
+  - Shortcut: *.pen rm*
+- `.penumbra additem [Merchant] [Item] [Price] [Amount]` 🔒
+  - Adds or updates merchant stock.
+  - Shortcut: *.pen ai [Merchant] [Item] [Price] [Amount]*
 
 ## Credits
 

--- a/Services/MerchantService.cs
+++ b/Services/MerchantService.cs
@@ -12,6 +12,7 @@ using UnityEngine;
 using static Penumbra.Plugin;
 using ProjectM.Gameplay.Scripting;
 using System.Globalization;
+using System;
 
 namespace Penumbra.Services;
 internal class MerchantService
@@ -450,6 +451,46 @@ internal class MerchantService
                 SpawnMerchant(wares.TraderPrefab, wares.Position, wares);
             }
         }
+    }
+
+    internal static void AddMerchantItem(int merchantIndex, PrefabGUID item, int price, int amount)
+    {
+        if (merchantIndex < 0)
+            return;
+
+        while (merchantIndex >= Merchants.Count)
+        {
+            Merchants.Add(new MerchantConfig
+            {
+                Name = $"Merchant{Merchants.Count + 1}",
+                OutputItems = Array.Empty<string>(),
+                OutputAmounts = Array.Empty<int>(),
+                InputItems = Array.Empty<string>(),
+                InputAmounts = Array.Empty<int>(),
+                StockAmounts = Array.Empty<int>(),
+                RestockTime = 60,
+                TraderPrefab = 0,
+                Position = string.Empty,
+                Roam = false
+            });
+        }
+
+        MerchantConfig config = Merchants[merchantIndex];
+
+        config.OutputItems = [..config.OutputItems, item.GuidHash.ToString()];
+        config.OutputAmounts = [..config.OutputAmounts, amount];
+        config.InputItems = [..config.InputItems, Plugin._tokensConfig.TokenItem.GuidHash.ToString()];
+        config.InputAmounts = [..config.InputAmounts, price];
+        config.StockAmounts = [..config.StockAmounts, amount];
+
+        RefreshMerchantWares();
+        Plugin.Instance.SaveMerchants();
+    }
+
+    internal static void RefreshMerchantWares()
+    {
+        _merchantWares.Clear();
+        PopulateMerchantWares();
     }
 
     /*


### PR DESCRIPTION
## Summary
- allow adding items to merchant stock with `.pen ai` command
- support merchant config updates in `MerchantService`
- enable saving merchants externally
- document the new command in README
- ignore stray Windows build directory

## Testing
- `dotnet build -c Release`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688938e20f78832d878c4e6140a0e93f