### PR TITLE
Use invariant culture for merchant item GUIDs

### DIFF
--- a/Services/MerchantService.cs
+++ b/Services/MerchantService.cs
@@ -477,9 +477,9 @@ internal class MerchantService
 
         MerchantConfig config = Merchants[merchantIndex];
 
-        config.OutputItems = [..config.OutputItems, item.GuidHash.ToString()];
+        config.OutputItems = [..config.OutputItems, item.GuidHash.ToString(CultureInfo.InvariantCulture)];
         config.OutputAmounts = [..config.OutputAmounts, amount];
-        config.InputItems = [..config.InputItems, Plugin._tokensConfig.TokenItem.GuidHash.ToString()];
+        config.InputItems = [..config.InputItems, Plugin._tokensConfig.TokenItem.GuidHash.ToString(CultureInfo.InvariantCulture)];
         config.InputAmounts = [..config.InputAmounts, price];
         config.StockAmounts = [..config.StockAmounts, amount];
 


### PR DESCRIPTION
## Summary
- ensure merchant item and token GUIDs use CultureInfo.InvariantCulture when serialized

## Testing
- `dotnet build /p:RunGenerateREADME=false`


------
https://chatgpt.com/codex/tasks/task_e_68969ad77950832d8addd9928d77fea4