### PR TITLE
Allow spawn merchant trader to be optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ Jairon O.; Odjit; Jera; Kokuren TCG and Gaming Shop; Rexxn; Eduardo G.; DirtyMik
 - `.penumbra getdaily`
   - Check time remaining or receive daily login reward if eligible.
   - Shortcut: *.pen gd*
-- `.penumbra spawnmerchant [TraderPrefab] [Wares]` 🔒
-  - Spawns merchant at mouse location with configured wares ('.pen sm 1631713257 3' will spawn a major noctem trader with the third wares as configured).
-  - Shortcut: *.pen sm [TraderPrefab] [Wares]*
+  - `.penumbra spawnmerchant [Wares] [TraderPrefab?]` 🔒 – If the trader prefab is omitted a random trader will be chosen.
+    - Spawns merchant at mouse location with configured wares ('.pen sm 1631713257 3' will spawn a major noctem trader with the third wares as configured).
+    - Shortcut: *.pen sm [Wares] [TraderPrefab?]*
 - `.penumbra removemerchant` 🔒
   - Removes hovered merchant.
   - Shortcut: *.pen rm*


### PR DESCRIPTION
## Summary
- allow the spawnmerchant command to accept an optional trader prefab argument
- select a random trader prefab when none is supplied using a cached prefab list
- document the updated command usage and random fallback in the README

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68caec817388832da98ece6923d73aee